### PR TITLE
fix: added GNOME 50 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "gspotify@sogi.is-a.dev",
   "name": "GSpotify & Downloader",
   "description": "A label, downloader and integrated Spotify controller for GNOME Shell. Uses system clipboard for menu actions. Uses spotdl for downloads. This extension is not affiliated, funded, or in any way associated with Spotify.",
-  "shell-version": ["46", "47", "48", "49"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "url": "https://github.com/sxoxgxi/gspotify",
   "settings-schema": "org.gnome.shell.extensions.gspotify",
   "gettext-domain": "gspotify",


### PR DESCRIPTION
Hello!
With the recent release of GNOME 50, I noticed that its support was lacking for this extension.
I tested and just adding the support in the metadata.json fixes everything, so here it is!